### PR TITLE
fix: json plugin did not transform from string

### DIFF
--- a/Boquila/Core/plugins/JsonRemoteConfigAdapterPlugin.swift
+++ b/Boquila/Core/plugins/JsonRemoteConfigAdapterPlugin.swift
@@ -44,10 +44,6 @@ public class JsonRemoteConfigAdapterPlugin: RemoteConfigAdapterPlugin {
             return nil
         }
         
-        guard isValidJson(stringValue) else {
-            return nil
-        }
-        
         do {
             return try jsonDecoder.decode(T.self, from: stringValue.data(using: .utf8)!)
         } catch let error {
@@ -67,14 +63,6 @@ public class JsonRemoteConfigAdapterPlugin: RemoteConfigAdapterPlugin {
             
             return nil
         }
-    }
-    
-    func isValidJson(_ value: String) -> Bool {
-        guard let data = value.data(using: .utf8) else {
-            return false
-        }
-        
-        return JSONSerialization.isValidJSONObject(data)
     }
     
 }

--- a/Boquila/Core/plugins/JsonRemoteConfigAdapterPlugin.swift
+++ b/Boquila/Core/plugins/JsonRemoteConfigAdapterPlugin.swift
@@ -36,7 +36,7 @@ public class JsonRemoteConfigAdapterPlugin: RemoteConfigAdapterPlugin {
         self.jsonDecoder = jsonDecoder
     }
     
-    public func transformValue<T: Codable>(_ value: Any) -> T? {
+    public func transformStringValue<T: Codable>(_ value: String) -> T? {
         guard let stringValue = value as? String else {
             return nil
         }


### PR DESCRIPTION
Realized in an app of mine that the mock adapter's transform from string function was never called. This is the fix to that. 